### PR TITLE
travis test PHP 5.6 - 7.2 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - composer --dev install

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "podlove/normalplaytime": "1.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "5.*.*"
     },
     "autoload": {
         "psr-0": { "Podlove\\Chapters": "lib/" }


### PR DESCRIPTION
We could also remove `dev`, `You are using the deprecated option "dev". Dev packages are installed by default now.`.

PHP 7.2 seemed to fail: `each()` used by PHPUnit is deprecated, PHPUnit update helped.